### PR TITLE
add therubyracer to drop nodejs requirement when building locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:centos7
+WORKDIR /tmp/site
+RUN yum install -y tar libcurl-devel zlib-devel patch rubygem-bundler ruby-devel git make gcc gcc-c++ redhat-rpm-config && yum clean all 
+
+# add these so bundle install works, even though eventually we'll use a volume
+# for our files
+ADD Gemfile  /tmp/Gemfile
+ADD Gemfile.lock /tmp/Gemfile.lock
+
+RUN bundle install
+
+EXPOSE 4000
+CMD [ "bundle", "exec", "jekyll", "serve", "--host=0.0.0.0", "--incremental" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM centos:centos7
+FROM fedora:25
+
 WORKDIR /tmp/site
-RUN yum install -y tar libcurl-devel zlib-devel patch rubygem-bundler ruby-devel git make gcc gcc-c++ redhat-rpm-config && yum clean all 
+
+RUN dnf install -y rubygem-bundler ruby-devel libffi-devel make gcc gcc-c++ \
+  redhat-rpm-config zlib-devel libxml2-devel libxslt-devel tar && dnf clean all 
 
 # add these so bundle install works, even though eventually we'll use a volume
 # for our files
-ADD Gemfile  /tmp/Gemfile
-ADD Gemfile.lock /tmp/Gemfile.lock
+ADD Gemfile  /tmp/site/Gemfile
+ADD Gemfile.lock /tmp/site/Gemfile.lock
 
 RUN bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,8 @@ gem "minima"
 # group :jekyll_plugins do
 #   gem "jekyll-github-metadata", "~> 1.0"
 # end
+
+# The CoffeeScript gem depends on execjs which requires a JavaScript runtime.
+# This does the trick without nodejs.
+gem "therubyracer"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       jekyll (>= 3.0)
     json (1.8.3)
     kramdown (1.11.1)
+    libv8 (3.16.14.15)
     liquid (3.0.6)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
@@ -112,6 +113,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    ref (2.0.0)
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
@@ -120,6 +122,9 @@ GEM
       faraday (~> 0.8, < 0.10)
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thread_safe (0.3.5)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
@@ -133,9 +138,4 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   minima
-
-RUBY VERSION
-   ruby 2.3.1p112
-
-BUNDLED WITH
-   1.13.2
+  therubyracer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       jekyll (>= 3.0)
     json (1.8.3)
     kramdown (1.11.1)
+    libv8 (3.16.14.15)
     liquid (3.0.6)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
@@ -116,6 +117,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    ref (2.0.0)
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
@@ -124,6 +126,9 @@ GEM
       faraday (~> 0.8, < 0.10)
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thread_safe (0.3.5)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
@@ -137,9 +142,4 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   minima
-
-RUBY VERSION
-   ruby 2.3.1p112
-
-BUNDLED WITH
-   1.13.2
+  therubyracer

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# install everything in a docker container
+
+# use semi-unique name so you can have multiple forks of the site
+# using their own containers
+CONTAINER_ID="builder_`basename $(pwd)`"
+
+# set SElinux context to allow docker to read the source directory
+chcon -Rt svirt_sandbox_file_t .
+
+# requires docker and being in the right group
+docker build -t $CONTAINER_ID .
+docker run --rm -p 4000:4000 -v "$(pwd)":/tmp/site $CONTAINER_ID
+


### PR DESCRIPTION
Therubyracer is required by coffeescript that is required by the github pages gem bundle. Looks like my ruby (on centos7 container) does not output the ruby version strings etc on the end of the gemfile, go figure..
