### PR TITLE
Script fixes

### DIFF
--- a/_scripts/toolbox-create
+++ b/_scripts/toolbox-create
@@ -8,7 +8,8 @@ run="toolbox run -c springboard-website"
 echo "## Installing RPM dependencies inside container..."
 $run sudo dnf install -y rubygem-bundler \
 	ruby-devel libffi-devel make gcc gcc-c++ redhat-rpm-config zlib-devel \
-	libxml2-devel libxslt-devel tar nodejs
+	libxml2-devel libxslt-devel tar nodejs \
+	glibc-all-langpacks
 
 echo "## Setting local gem path"
 $run bundle config path .gem

--- a/_scripts/toolbox-create
+++ b/_scripts/toolbox-create
@@ -1,7 +1,7 @@
 #!/usr/bin/bash -e
 
 echo "## Creating website container..."
-toolbox create -c springboard-website
+toolbox create -c springboard-website -r 32
 
 run="toolbox run -c springboard-website"
 


### PR DESCRIPTION
- Use Fedora 32, to minimize surprises. (This should be bumped up every stable release.)
- Added glibc language packs to make sure UTF-8 (and other languages) are supported.